### PR TITLE
CP-24360: Initialise VM.platform['device-model'] values - Stage 1

### DIFF
--- a/ocaml/xapi/vm_platform.ml
+++ b/ocaml/xapi/vm_platform.ml
@@ -44,6 +44,10 @@ let igd_passthru_key = Xapi_globs.igd_passthru_key
 let featureset = "featureset"
 let nested_virt = "nested-virt"
 
+(* The default value of device model should be set as
+   'qemu-trad', 'qemu-upstream-compat', 'qemu-upstream' according to QEMU-upstream feature release stages *)
+let default_device_model_default_value = "qemu-trad"
+
 (* This is only used to block the 'present multiple physical cores as one big hyperthreaded core' feature *)
 let filtered_flags = [
   acpi;

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -505,6 +505,7 @@ let create ~__context ~name_label ~name_description
     ~nested_virt:false
     ~nomigrate:false
   ;
+  let platform = platform |> (Xapi_vm_helpers.ensure_device_model_profile_present ~__context ~hVM_boot_policy) in
   Db.VM.create ~__context ~ref:vm_ref ~uuid:(Uuid.to_string uuid)
     ~power_state:(`Halted) ~allowed_operations:[]
     ~current_operations:[]

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -276,6 +276,9 @@ let copy_vm_record ?(snapshot_info_record) ~__context ~vm ~disk_op ~new_name ~ne
   let is_vmss_snapshot =
       is_a_snapshot && (Xapi_vmss.is_vmss_snapshot ~__context) in
 
+  let hVM_boot_policy = all.Db_actions.vM_HVM_boot_policy in
+  let platform = all.Db_actions.vM_platform |> (Xapi_vm_helpers.ensure_device_model_profile_present ~__context ~hVM_boot_policy) in
+
   (* create a new VM *)
   Db.VM.create ~__context
     ~ref
@@ -313,11 +316,11 @@ let copy_vm_record ?(snapshot_info_record) ~__context ~vm ~disk_op ~new_name ~ne
     ~actions_after_shutdown:all.Db_actions.vM_actions_after_shutdown
     ~actions_after_reboot:all.Db_actions.vM_actions_after_reboot
     ~actions_after_crash:all.Db_actions.vM_actions_after_crash
-    ~hVM_boot_policy:all.Db_actions.vM_HVM_boot_policy
+    ~hVM_boot_policy
     ~hVM_boot_params:all.Db_actions.vM_HVM_boot_params
     ~hVM_shadow_multiplier:all.Db_actions.vM_HVM_shadow_multiplier
     ~suspend_VDI:Ref.null
-    ~platform:all.Db_actions.vM_platform
+    ~platform
     ~pV_kernel:all.Db_actions.vM_PV_kernel
     ~pV_ramdisk:all.Db_actions.vM_PV_ramdisk
     ~pV_args:all.Db_actions.vM_PV_args

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -989,3 +989,12 @@ let with_vm_operation ~__context ~self ~doc ~op ?(strict=true) ?policy f =
          Helpers.Early_wakeup.broadcast (Datamodel._vm, Ref.string_of self);
        with
          _ -> ())
+
+(* Device Model Profiles *)
+let ensure_device_model_profile_present ~__context ~hVM_boot_policy platform =
+  let is_hvm = hVM_boot_policy <> "" in
+  let default = Vm_platform.(device_model, default_device_model_default_value) in
+  if not is_hvm || List.mem_assoc Vm_platform.device_model platform then
+    platform
+  else (* only add device-model to an HVM VM platform if it is not already there *)
+    default :: platform


### PR DESCRIPTION
The HVM templates of a host shall have a `VM.platform["device-model"]`
field containing the default device model according to the QEMU feature
release stages.

When a VM is created from a template, if `VM.platform["device-model"]`
is not set, then it shall be initialized from the default device model
profile.

Signed-off-by: Liang Dai <liang.dai1@citrix.com>